### PR TITLE
Fix overflow in pre blocks

### DIFF
--- a/share/templates/style.css
+++ b/share/templates/style.css
@@ -249,6 +249,7 @@ pre {
   white-space: pre;
   border-collapse: collapse;
   width: 100%;
+  overflow: auto;
 }
 
 .code-listing td {


### PR DESCRIPTION
Since the change from https://github.com/perladvent/Perl-Advent/pull/332 does not seem to have any effect, I think the CSS change has to be made to this style.css file.