### PR TITLE
Fix overflow on pre + make code bold

### DIFF
--- a/share/templates/style.css
+++ b/share/templates/style.css
@@ -239,6 +239,8 @@ pre {
   color: <% $color{codeFG} %>;
   font-family: monospace;
   width: 100%;
+  font-weight: bold;
+  overflow: auto;
 }
 
 .code-listing {
@@ -249,6 +251,7 @@ pre {
   white-space: pre;
   border-collapse: collapse;
   width: 100%;
+  font-weight: bold;
   overflow: auto;
 }
 


### PR DESCRIPTION
- Completes #1 
- Moves usual extra styles (see for instance [2014.css](https://github.com/perladvent/Perl-Advent/blob/main/2014/share/static/2014.css)) to WWW::AdventCalendar main `style.css`
