### PR TITLE
Provide option --incoming-dir to also generate incoming articles using some availabe seats if any

### DIFF
--- a/bin/advcal
+++ b/bin/advcal
@@ -14,6 +14,7 @@ use Getopt::Long::Descriptive 0.083;
   advcal [-aot] [long options...]
     -c --config       the ini file to read for configuration
     -a --article-dir  the root of articles
+    -i --incoming-dir the root of incoming articles
     --share-dir       the root of shared files
     -o --output-dir   output directory
     --today           the day we treat as "today"; default to today
@@ -29,6 +30,7 @@ my ($opt, $usage) = describe_options(
   '%c %o',
   [ 'config|c=s',      'the ini file to read for configuration'            ],
   [ 'article-dir|a=s', 'root of articles',     { default => './articles' } ],
+  [ 'incoming-dir|i=s','root of incoming',     { default => undef        } ],
   [ 'share-dir=s',     'root of shared files', { default => './share'    } ],
   [ 'output-dir|o=s',  'output directory',     { default => './out'      } ],
   [ 'today=s',         'the day we treat as "today"; default to today'     ],


### PR DESCRIPTION
After a first pass reading entries in `articles` with names specifying days (e.g. `2024-12-01.pod`, `2024-12-02.pod`) we start a second pass reading entries in `incoming`. They have names like `ornamenting-jingle-bells.pod` or `trimming-your-holiday-tree.pod` so we allocate a day from pool of available ones. 

We don't want to change normal running of `advcal` so nothing will happen if we don't explicitely provide the option `-i` or `--incoming-dir`. 

This is a better version of https://github.com/perladvent/Perl-Advent/pull/418 what do you think @openstrike 😃 